### PR TITLE
#3 add operators to load timelines and projects

### DIFF
--- a/shift_resolve.py
+++ b/shift_resolve.py
@@ -172,7 +172,8 @@ class DVR_ClipGet(DVR_Base):
                     targetClip = clip
                     break
         else:
-            raise ValueError("Not recognized get method.")
+            raise ValueError("Get Method '{0}' is not supported. Please choose between: "
+                             "'ByName'.".format(getMethod))
 
         self.getPlug("clip", SDirection.kOut).setValue(targetClip)
         super(self.__class__, self).execute()
@@ -400,7 +401,8 @@ class DVR_FolderGet(DVR_Base):
                 raise RuntimeError("The folder couldn't be found using the FullPath get method. "
                                    "Check that the Folder path is correct: \n {0}".format(str(e)))
         else:
-            raise ValueError("GetMethod value not recognised.")
+            raise ValueError("Get Method '{0}' is not supported. Please choose between: "
+                             "'Current', 'Root', 'FullPath'.".format(getMethod))
 
 
         self.getPlug("folder", SDirection.kOut).setValue(folder)
@@ -824,15 +826,14 @@ class DVR_TimelineGet(DVR_Base):
                 timeline = project.GetTimelineByIndex(timeIdx)
             except Exception as e:
                 raise RuntimeError("The timeline at index {0} could not be get.".format(timeIdx))
-
-
         elif getMethod == "Current":
             try:
                 timeline = project.GetCurrentTimeline()
             except Exception as e:
                 raise RuntimeError("The current timeline could not be get.")
         else:
-            raise ValueError("Get Method '{0}' is not supported".format(getMethod))
+            raise ValueError("Get Method '{0}' is not supported. Please choose between: "
+                             "'ByName', 'ByIndex', 'Current'.".format(getMethod))
         self.getPlug("timeline", SDirection.kOut).setValue(timeline)
         super(self.__class__, self).execute()
 
@@ -1140,7 +1141,8 @@ class DVR_TimelineItemsGet(DVR_Base):
             if not items:
                 logger.warning("Track name not found or the track is empty.")
         else:
-            raise ValueError("Get method '{0}' is not valid. Please choose between 'ByTrackIdx', 'ByTrackName' or 'All'.".format(getMethod))
+            raise ValueError("Get method '{0}' is not valid. Please choose between "
+                             "'ByTrackIdx', 'ByTrackName' or 'All'.".format(getMethod))
 
 
         self.getPlug("items", SDirection.kOut).setValue(items)


### PR DESCRIPTION
# Issue
Resolve #3 

# Description
Create all the required operators to load timeline and projects. Plus Manage the folders and clips from the media pool.

Must be merge after #2 

# Definition Of Done

Basic Operators:
- [x] ProjectImport
- [x] MetadataGet
- [x] TimelineImport
- [x] TimelineSet
- [x] ClipsGet
- [x] ClipGet
- [x] FolderAdd
- [x] FolderGet
- [x] FolderSet
  
# How Has This Been Tested?

- [x] Tested in Davinci Resolve and in the edit load workflow.

![image](https://github.com/Inbibo/Shift_Resolve/assets/154216966/b9ce3c1c-a8d6-4fd5-a063-2f9bb16812b3)
![image](https://github.com/Inbibo/Shift_Resolve/assets/154216966/d7e0372a-e39c-40c6-897a-d26957dd4279)


# Parameters For PR Approval

- If 3 heads approve a PR (inc Marco) in 1 week it is approved.
- If 3 heads approve a PR in 2 weeks (without Marco) it is approved.
- Priority will automatially receive a bump to High 3 days before initial 2 week deadline.

