### PR TITLE
#6 create take operators

### DIFF
--- a/shift_resolve.py
+++ b/shift_resolve.py
@@ -801,18 +801,14 @@ class DVR_TakeAdd(DVR_Base):
         if startFrame > endFrame:
             raise ValueError("The given frame range is not valid: {0}-{1}".format(startFrame, endFrame))
         msg = "No error provided"
-        if startFrame == endFrame:  # We use the equal condition like flag to ignore the frame range.
-            try:
+        try:
+            if startFrame == endFrame:  # We use the equal condition like flag to ignore the frame range.
                 result = item.AddTake(clip)
-            except Exception as e:
-                msg = str(e)
-                result = False
-        else:
-            try:
+            else:
                 result = item.AddTake(clip, startFrame, endFrame)
-            except Exception as e:
-                msg = str(e)
-                result = False
+        except Exception as e:
+            result = False
+            msg = str(e)
         if not result:
             raise RuntimeError("The take could not be added: {0}".format(msg))
         super(self.__class__, self).execute()


### PR DESCRIPTION
# Issue
Resolve #6 

# Description
To implement tools to update clips in the Timelines of resolve we need some extra operators. To take advantage of the Take Selector feature from Resolve we need new operators to use the API options for the Take Selector. And a extra operator for the clips to be able to get the name of a clip.

# Definition Of Done
Implement the operators to work with takes

Basic Operators:
- [x] DVR_ClipPropertyGet
- [x] DVR_TakeAdd
- [x] DVR_TakeGet
- [x] DVR_TakeSet
  
# How Has This Been Tested?
Tested in Resolve, adding some takes and changing the salection.

![image](https://github.com/Inbibo/Shift_Resolve/assets/154216966/5c1d6905-d879-4868-a4c4-6485511c86f6)

Example of workflow:
![image](https://github.com/Inbibo/Shift_Resolve/assets/154216966/78e1268b-db1c-44c9-8fd7-b188c11ebdd2)


# Parameters For PR Approval

- If 3 heads approve a PR (inc Marco) in 1 week it is approved.
- If 3 heads approve a PR in 2 weeks (without Marco) it is approved.
- Priority will automatially receive a bump to High 3 days before initial 2 week deadline.

