### PR TITLE
#14 Add input class check in all nodes from the resolve catalog

### DIFF
--- a/shift_resolve.py
+++ b/shift_resolve.py
@@ -174,7 +174,7 @@ class DVR_Base(SOperator):
                 raise ValueError("The {0} input is not valid, got {1}".format(objExpected, objClass))
         else:
             if not isinstance(objIn, list):
-                raise ValueError("The input have to be a list of {0} instances, "
+                raise ValueError("The input has to be a list of {0} instances, "
                                  "not {1}.".format(objExpected, self.getObjClass(objIn)))
             for element in objIn:
                 raiseError, objClass = self.checkIndividualClass(element, objExpected)


### PR DESCRIPTION
## Issue
Fixes #14 

## Description
The Shift_Resolve operators were not checking the plugs inputs file types properly. Now each operator check the instance input plugs to make sure that the input object is the spected type: folder, project, timeline, item, clip,...

## Definition Of Done

- [x] Add the class check for folder objects.
- [x] Call the checkClass function in all operators with instance inputs.

## Testing
Tested execution each operator with the right input and a wrong input:

- [x] DVR_ClipPropertyGet
- [x] DVR_ClipGet
- [x] DVR_ClipsGet
- [x] DVR_FolderAdd
- [x] DVR_FolderGet
- [x] DVR_FolderSet
- [x] DVR_MetadataGet
- [x] DVR_MetadataSet
- [x] DVR_ProjectExport
- [x] DVR_ProjectGet
- [ ] ~DVR_ProjectImport~ Does not have instance plugs
- [ ] ~DVR_TakeAdd~ Already had the check
- [ ] ~DVR_TakeGet~ Already had the check
- [ ] ~DVR_TakeSet~ Already had the check
- [x] DVR_TimelineExport
- [x] DVR_TimelineGet
- [x] DVR_TimelineSet
- [x] DVR_TimelineImport
- [x] DVR_TimelineItemGet
- [x] DVR_TimelineItemsGet
- [x] DVR_TimelineNameGet
- [x] DVR_TimelineNameSet

![temp](https://github.com/user-attachments/assets/5b103491-b6ea-499d-93da-6eb99b74c446)

## Parameters For PR Approval

If 3 heads approve a PR (inc Marco) in 1 week it is approved.
If 3 heads approve a PR in 2 weeks (without Marco) it is approved.
Priority will automatially receive a bump to High 3 days before initial 2 week deadline.