### PR TITLE
#7 add ProjectOpen operator to the catalog

### DIFF
--- a/shift_resolve.py
+++ b/shift_resolve.py
@@ -743,7 +743,7 @@ class DVR_ProjectGet(DVR_Base):
 
 
 class DVR_ProjectOpen(DVR_Base):
-    """Operator to open a project with him name.
+    """Operator to open a project with the provided name.
     Works in Davinci Resolve.
 
     """
@@ -768,7 +768,7 @@ class DVR_ProjectOpen(DVR_Base):
         self.addPlug(o_project)
 
     def execute(self, force=False):
-        """Returns the current project from Davinci Resolve.
+        """Tries to load a project with the given name in Davinci Resolve. If the loading fails, it raises an error.
 
         @param force Bool: Sets the flag for forcing the execution even on clean nodes. (Default = False)
 
@@ -777,8 +777,8 @@ class DVR_ProjectOpen(DVR_Base):
         projectName = self.getPlug("projectName", SDirection.kIn).value
         project = projectManager.LoadProject(projectName)
         if not project:
-            raise RuntimeError("The project could not been open. Check that aproject named {0} exists in "
-                               "the current project folder from Resolve.".format(projectName))
+            raise RuntimeError("The project could not be opened. Please, check if a project "
+                               "named {0} exists in the current project folder in Resolve.".format(projectName))
         self.getPlug("project", SDirection.kOut).setValue(project)
         super(self.__class__, self).execute()
 


### PR DESCRIPTION
## Issue

Fixes #7

## Description

We need an operator to open a project already imported in the Resolve database. The ProjectImport operator can import a project in the Resolve database, however does not open the project and does not return the instance.

To open a project we need the project name. This node have the project name like an input and returns the project instance of the open project.

## Definition Of Done

- [x] Create the ProjectOpen operator
- [x] Return the Project object.
- [x] Check that the project could be open and raise and error if not


## Testing

Tested opening imported project in resolve.
![temp](https://github.com/user-attachments/assets/7b54689a-ea16-4725-8152-211cb67c2862)


## Parameters For PR Approval

If 3 heads approve a PR (inc Marco) in 1 week it is approved.
If 3 heads approve a PR in 2 weeks (without Marco) it is approved.
Priority will automatially receive a bump to High 3 days before initial 2 week deadline.