### PR TITLE
#18 Adds the FolderNameGet operator to the catalog

### DIFF
--- a/shift_resolve.py
+++ b/shift_resolve.py
@@ -286,7 +286,6 @@ class DVR_ClipGet(DVR_Base):
 
 class DVR_ClipsGet(DVR_Base):
     """Operator to get all the clips from a Resolve folder.
-
     Works in Davinci Resolve.
 
     """
@@ -331,7 +330,6 @@ class DVR_ClipsGet(DVR_Base):
 
 class DVR_FolderAdd(DVR_Base):
     """Operator to create a folder inside other folder with the given name in Resolve.
-
     Works in Davinci Resolve.
 
     """
@@ -604,7 +602,6 @@ class DVR_FolderSet(DVR_Base):
 class DVR_MetadataGet(DVR_Base):
     """Operator to get the metadata of a given clip of the Media Pool.
     Allows the creation of new plugs. It will pick output plug names like field of the metadata to be read from the given clip and will store the obtained value inside them. Custom input plugs will be ignored.
-
     Works in Davinci Resolve.
 
     """


### PR DESCRIPTION
## Issue
Fixes #18 

## Description
We need an operator to get the name of a folder.

## Definition Of Done

- [x] Create the FolderNameGet operator.

## Testing
Tested getting the name of a master folder and a custom user folder.
![temp](https://github.com/user-attachments/assets/cc9218cb-03c2-4db9-ab88-02fd08636773)

## Parameters For PR Approval

If 3 heads approve a PR (inc Marco) in 1 week it is approved.
If 3 heads approve a PR in 2 weeks (without Marco) it is approved.
Priority will automatially receive a bump to High 3 days before initial 2 week deadline.