### PR TITLE
#20 remove editable flags from not required nodes

### DIFF
--- a/shift_resolve.py
+++ b/shift_resolve.py
@@ -226,7 +226,7 @@ class DVR_ClipGet(DVR_Base):
     """
 
     def __init__(self, code, parent):
-        super(self.__class__, self).__init__(code, editable=True, parent=parent)
+        super(self.__class__, self).__init__(code, parent=parent)
         i_clips = SPlug(
             code="clips",
             value=None,
@@ -292,7 +292,7 @@ class DVR_ClipsGet(DVR_Base):
     """
 
     def __init__(self, code, parent):
-        super(self.__class__, self).__init__(code, editable=True, parent=parent)
+        super(self.__class__, self).__init__(code, parent=parent)
         i_folder = SPlug(
             code="folder",
             value=None,
@@ -337,7 +337,7 @@ class DVR_FolderAdd(DVR_Base):
     """
 
     def __init__(self, code, parent):
-        super(self.__class__, self).__init__(code, editable=True, parent=parent)
+        super(self.__class__, self).__init__(code, parent=parent)
         i_project = SPlug(
             code="project",
             value=None,
@@ -400,7 +400,7 @@ class DVR_FolderGet(DVR_Base):
     """
 
     def __init__(self, code, parent):
-        super(self.__class__, self).__init__(code, editable=True, parent=parent)
+        super(self.__class__, self).__init__(code, parent=parent)
         i_project = SPlug(
             code="project",
             value=None,
@@ -521,7 +521,7 @@ class DVR_FolderSet(DVR_Base):
     """
 
     def __init__(self, code, parent):
-        super(self.__class__, self).__init__(code, editable=True, parent=parent)
+        super(self.__class__, self).__init__(code, parent=parent)
         i_project = SPlug(
             code="project",
             value=None,


### PR DESCRIPTION
## Issue
Fixes #20

## Description
Some operators are flagged like editable but they are not required to be modify in terms of plugs. We need to remove it to avoid the user adding custom plugs that won't be used.

## Definition Of Done
Remove editable flag from:

- [x] ClipGet
- [x] ClipsGet
- [x] FolderAdd
- [x] FolderGet
- [x] FolderSet

## Testing
Testing all the modified operators and checking that now the UI does not allow to create plugs on them.
![image](https://github.com/user-attachments/assets/c2a4991d-5e06-44fd-8190-f9265a6fa775)


## Parameters For PR Approval

If 3 heads approve a PR (inc Marco) in 1 week it is approved.
If 3 heads approve a PR in 2 weeks (without Marco) it is approved.
Priority will automatially receive a bump to High 3 days before initial 2 week deadline.